### PR TITLE
Fix: Pre-built rules not displaying for installed apps

### DIFF
--- a/app/src/main/java/com/donotnotify/donotnotify/ui/screens/PrebuiltRulesScreen.kt
+++ b/app/src/main/java/com/donotnotify/donotnotify/ui/screens/PrebuiltRulesScreen.kt
@@ -50,7 +50,9 @@ fun PrebuiltRulesScreen(
         prebuiltRules = repository.getPrebuiltRules()
     }
 
-    val installedAppPackages = packageManager.getInstalledPackages(PackageManager.GET_META_DATA)
+    // Use getInstalledApplications with MATCH_ALL to get a more complete list of installed apps,
+    // as getInstalledPackages can be subject to package visibility restrictions on newer Android versions.
+    val installedAppPackages = packageManager.getInstalledApplications(PackageManager.MATCH_ALL)
         .map { it.packageName }
 
     Log.i("PrebuiltRulesScreen", "Installed App Packages: $installedAppPackages")


### PR DESCRIPTION
The pre-built rules were not being displayed in the UI, even when the corresponding applications were installed on the device.

This was caused by the use of packageManager.getInstalledPackages(PackageManager.GET_META_DATA), which can provide an incomplete list of installed applications on newer Android versions due to package visibility restrictions.

The fix replaces the call with packageManager.getInstalledApplications(PackageManager.MATCH_ALL), which returns a more comprehensive list of installed applications. This ensures that the pre-built rules are correctly filtered and displayed for all relevant installed apps.